### PR TITLE
Update index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 # LF Decentralized Trust
 
-Welcome to the LFDT contributor hub — your starting point to **use, contribute, and maintain** projects across the decentralized trust ecosystem.  
+Welcome to the LFDT Contributor Hub — your starting point to **participate, contribute, and maintain** projects across the decentralized trust ecosystem.  
 This site brings together step-by-step guides, contributor ladders, maintainer playbooks, mentorship paths, and end-user contribution guidance.  
 Whether you ship code, shape governance, write docs, or run LFDT projects in production, you’ll find a clear path to participate.
 
@@ -11,7 +11,7 @@ Whether you ship code, shape governance, write docs, or run LFDT projects in pro
 
 <div class="grid cards" markdown>
 
-- :octicons-project-symlink-16:{ .lg .middle } __[Contribute to a project](./contribute/index.md)__
+- :octicons-project-symlink-16:{ .lg .middle } __[Contribute to a Project](./contribute/index.md)__
 - :fontawesome-solid-hands-helping:{ .lg .middle } __[Maintain a Project](./maintain/index.md)__
 - :fontawesome-solid-code-merge:{ .lg .middle } __[Contributing as an End User](./end-users.md)__
 - :fontawesome-solid-chalkboard-teacher:{ .lg .middle } __[Join a Mentorship Program](./mentorship/index.md)__


### PR DESCRIPTION
capitalization issue and change "use" to "participate" in the opening statement so that it does not imply that the site visitor will find technical getting started materials in this site.